### PR TITLE
Fix for images with index of minus one

### DIFF
--- a/js/frameScrub.js
+++ b/js/frameScrub.js
@@ -1,13 +1,13 @@
 (function($) {
 
     $.fn.frameScrub = function(options) {
-	
+
 		function preloader(a) {
 		  for (var i = 0; i < a.length; i++) {
 		    $("<img />").attr("src", a[i]);
 		  }
 		}
-	
+
 		var settings = $.extend({
             defaultImage : null,
 			verticalAlignment: null,
@@ -23,24 +23,24 @@
 				imgs = [],
 				waiter = "",
 				titles = [];
-				
+
 			$((that).children("img")).each(function(){
 				imgs.push($(this).attr("src"));
-			});	
-			
+			});
+
 			preloader(imgs);
-							
+
 			function init(){
-				
+
 				$(that).css("position","relative");
-				
+
 				$(that).children('img').map(function(){
 					var pw = $(this).width(),
 						ph = $(this).height(),
 					    src = $(this).attr('src').split('/'),
 						newW,
 						newH;
-													
+
 					if(settings.frameWidth){
 						newW = settings.frameWidth + "px";
 						newH = ((ph * settings.frameWidth)/pw) + "px";
@@ -50,13 +50,13 @@
 					}
 					$(this).css({"margin": "auto", "display":"inline-block", "position" : "absolute", "left" : "0", "width": newW, "height": newH, "min-height": $(that).height(), "min-width": (pw * $(that).height())/ph});
 				});
-			
+
 			}
-			
+
 			init();
-			
+
 			$(this).find("img").css("z-index","0");
-			
+
 			if(settings.defaultImage){
 				$(this).find("img#" + settings.defaultImage).css("z-index","1");
 			}else{
@@ -65,9 +65,9 @@
 			if(settings.showTitles){
 				$("#" + settings.showTitles).html(settings.defaultImage ? $(this).find("img#" + settings.defaultImage).attr('title') : $(this).find("img").first().attr('title'));
 			  }
-			
-			remargin();   
-			
+
+			remargin();
+
 			function remargin(){
 				if(settings.verticalAlignment){
 					$(that).children("img").map(function(){
@@ -83,24 +83,24 @@
 								break;
 							}
 					});
-				
+
 				}
 			}
-			
+
 			$(window).resize(function(){
 				w = $(that).width();
 				switcher = w / num;
 				waiter = "";
 				waiter = setTimeout(remargin,500);
 			});
-			
+
 			if(settings.showTitle){
 				$(that).children('img').map(function(){
 					var title = $(this).attr('title');
 					titles.push(title);
 				});
 			}
-			
+
 			$(this).on("mouseenter", function(event){
 				  if(settings.defaultImage){
 					$(this).find("img#" + settings.defaultImage).css("z-index","0");
@@ -109,7 +109,7 @@
 				  }
 				showMouseX(event,$(this).attr("id"));
 			});
-			
+
 			$(this).on("mousemove", function(event){
 			    showMouseX(event,$(this).attr("id"));
 			});
@@ -129,6 +129,7 @@
 			      function showMouseX(e,that){
 			        var offset = $("#" + that).offset();
 			        var imgNum = (e.clientX - offset.left) < w ? Math.floor((e.clientX - offset.left)/switcher) : imgs.length - 1;
+              if (imgNum < 0) { imgNum = 0;  }
 			        showImage(imgNum,that);
 			      }
 


### PR DESCRIPTION
If you carefully hover on the very left edge of a frameScrub it
sometimes shows the last image (instead of the first as you would
expect). This is because it incorrectly sets imgNum to -1 in
showMouseX()

See video here https://dl.dropboxusercontent.com/u/3406838/framescrub/index.html
